### PR TITLE
Make `DiffableDataSourceSnapshot` struct

### DIFF
--- a/Sources/DiffableDataSourceSnapshot.swift
+++ b/Sources/DiffableDataSourceSnapshot.swift
@@ -1,7 +1,7 @@
 /// A class for backporting `NSDiffableDataSourceSnapshot` introduced in iOS 13.0+, macOS 10.15+, tvOS 13.0+.
 /// Represents the mutable state of diffable data source of UI.
-public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIdentifierType: Hashable> {
-    internal let structure = SnapshotStructure<SectionIdentifierType, ItemIdentifierType>()
+public struct DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> where SectionIdentifierType : Hashable, ItemIdentifierType : Hashable {
+    internal var structure = SnapshotStructure<SectionIdentifierType, ItemIdentifierType>()
 
     /// Creates a new empty snapshot object.
     public init() {}
@@ -81,7 +81,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifiers: The item identifiers to be appended.
     ///   - sectionIdentifier: An identifier of section to append the given identiciers.
-    public func appendItems(_ identifiers: [ItemIdentifierType], toSection sectionIdentifier: SectionIdentifierType? = nil) {
+    public mutating func appendItems(_ identifiers: [ItemIdentifierType], toSection sectionIdentifier: SectionIdentifierType? = nil) {
         structure.append(itemIDs: identifiers, to: sectionIdentifier)
     }
 
@@ -90,7 +90,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifiers: The item identifiers to be inserted.
     ///   - beforeIdentifier: An identifier of item.
-    public func insertItems(_ identifiers: [ItemIdentifierType], beforeItem beforeIdentifier: ItemIdentifierType) {
+    public mutating func insertItems(_ identifiers: [ItemIdentifierType], beforeItem beforeIdentifier: ItemIdentifierType) {
         structure.insert(itemIDs: identifiers, before: beforeIdentifier)
     }
 
@@ -99,7 +99,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifiers: The item identifiers to be inserted.
     ///   - afterIdentifier: An identifier of item.
-    public func insertItems(_ identifiers: [ItemIdentifierType], afterItem afterIdentifier: ItemIdentifierType) {
+    public mutating func insertItems(_ identifiers: [ItemIdentifierType], afterItem afterIdentifier: ItemIdentifierType) {
         structure.insert(itemIDs: identifiers, after: afterIdentifier)
     }
 
@@ -107,12 +107,12 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     ///
     /// - Parameters:
     ///   - identifiers: The item identifiers to be deleted.
-    public func deleteItems(_ identifiers: [ItemIdentifierType]) {
+    public mutating func deleteItems(_ identifiers: [ItemIdentifierType]) {
         structure.remove(itemIDs: identifiers)
     }
 
     /// Deletes the all items in the snapshot.
-    public func deleteAllItems() {
+    public mutating func deleteAllItems() {
         structure.removeAllItems()
     }
 
@@ -121,7 +121,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifier: An item identifier to be moved.
     ///   - toIdentifier: An identifier of item.
-    public func moveItem(_ identifier: ItemIdentifierType, beforeItem toIdentifier: ItemIdentifierType) {
+    public mutating func moveItem(_ identifier: ItemIdentifierType, beforeItem toIdentifier: ItemIdentifierType) {
         structure.move(itemID: identifier, before: toIdentifier)
     }
 
@@ -130,7 +130,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifier: An item identifier to be moved.
     ///   - toIdentifier: An identifier of item.
-    public func moveItem(_ identifier: ItemIdentifierType, afterItem toIdentifier: ItemIdentifierType) {
+    public mutating func moveItem(_ identifier: ItemIdentifierType, afterItem toIdentifier: ItemIdentifierType) {
         structure.move(itemID: identifier, after: toIdentifier)
     }
 
@@ -138,7 +138,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     ///
     /// - Parameters:
     ///   - identifiers: The item identifiers to be reloaded.
-    public func reloadItems(_ identifiers: [ItemIdentifierType]) {
+    public mutating func reloadItems(_ identifiers: [ItemIdentifierType]) {
         structure.update(itemIDs: identifiers)
     }
 
@@ -146,7 +146,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     ///
     /// - Parameters:
     ///   - identifiers: The section identifiers to be appended.
-    public func appendSections(_ identifiers: [SectionIdentifierType]) {
+    public mutating func appendSections(_ identifiers: [SectionIdentifierType]) {
         structure.append(sectionIDs: identifiers)
     }
 
@@ -155,7 +155,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifiers: The section identifiers to be inserted.
     ///   - toIdentifier: An identifier of setion.
-    public func insertSections(_ identifiers: [SectionIdentifierType], beforeSection toIdentifier: SectionIdentifierType) {
+    public mutating func insertSections(_ identifiers: [SectionIdentifierType], beforeSection toIdentifier: SectionIdentifierType) {
         structure.insert(sectionIDs: identifiers, before: toIdentifier)
     }
 
@@ -164,7 +164,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifiers: The section identifiers to be inserted.
     ///   - toIdentifier: An identifier of setion.
-    public func insertSections(_ identifiers: [SectionIdentifierType], afterSection toIdentifier: SectionIdentifierType) {
+    public mutating func insertSections(_ identifiers: [SectionIdentifierType], afterSection toIdentifier: SectionIdentifierType) {
         structure.insert(sectionIDs: identifiers, after: toIdentifier)
     }
 
@@ -172,7 +172,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     ///
     /// - Parameters:
     ///   - identifiers: The section identifiers to be deleted.
-    public func deleteSections(_ identifiers: [SectionIdentifierType]) {
+    public mutating func deleteSections(_ identifiers: [SectionIdentifierType]) {
         structure.remove(sectionIDs: identifiers)
     }
 
@@ -181,7 +181,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifier: A section identifier to be moved.
     ///   - toIdentifier: An identifier of section.
-    public func moveSection(_ identifier: SectionIdentifierType, beforeSection toIdentifier: SectionIdentifierType) {
+    public mutating func moveSection(_ identifier: SectionIdentifierType, beforeSection toIdentifier: SectionIdentifierType) {
         structure.move(sectionID: identifier, before: toIdentifier)
     }
 
@@ -190,7 +190,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     /// - Parameters:
     ///   - identifier: A section identifier to be moved.
     ///   - toIdentifier: An identifier of section.
-    public func moveSection(_ identifier: SectionIdentifierType, afterSection toIdentifier: SectionIdentifierType) {
+    public mutating func moveSection(_ identifier: SectionIdentifierType, afterSection toIdentifier: SectionIdentifierType) {
         structure.move(sectionID: identifier, after: toIdentifier)
     }
 
@@ -198,7 +198,7 @@ public class DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIde
     ///
     /// - Parameters:
     ///   - identifiers: The section identifiers to be reloaded.
-    public func reloadSections(_ identifiers: [SectionIdentifierType]) {
+    public mutating func reloadSections(_ identifiers: [SectionIdentifierType]) {
         structure.update(sectionIDs: identifiers)
     }
 }

--- a/Sources/Internal/DiffableDataSourceCore.swift
+++ b/Sources/Internal/DiffableDataSourceCore.swift
@@ -48,7 +48,7 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
     }
 
     func snapshot() -> DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> {
-        let snapshot = DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>()
+        var snapshot = DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>()
         snapshot.structure.sections = currentSnapshot.structure.sections
         return snapshot
     }

--- a/Sources/Internal/SnapshotStructure.swift
+++ b/Sources/Internal/SnapshotStructure.swift
@@ -1,7 +1,7 @@
 import Foundation
 import DifferenceKit
 
-final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
+struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
     struct Item: Differentiable, Equatable {
         var differenceIdentifier: ItemID
         var isReloaded: Bool
@@ -68,7 +68,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         return itemPositionMap()[itemID]?.section.differenceIdentifier
     }
 
-    func append(itemIDs: [ItemID], to sectionID: SectionID? = nil, file: StaticString = #file, line: UInt = #line) {
+    mutating func append(itemIDs: [ItemID], to sectionID: SectionID? = nil, file: StaticString = #file, line: UInt = #line) {
         let index: Array<Section>.Index
 
         if let sectionID = sectionID {
@@ -90,7 +90,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections[index].elements.append(contentsOf: items)
     }
 
-    func insert(itemIDs: [ItemID], before beforeItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
+    mutating func insert(itemIDs: [ItemID], before beforeItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
         guard let itemPosition = itemPositionMap()[beforeItemID] else {
             specifiedItemIsNotFound(beforeItemID, file: file, line: line)
         }
@@ -99,7 +99,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections[itemPosition.sectionIndex].elements.insert(contentsOf: items, at: itemPosition.itemRelativeIndex)
     }
 
-    func insert(itemIDs: [ItemID], after afterItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
+    mutating func insert(itemIDs: [ItemID], after afterItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
         guard let itemPosition = itemPositionMap()[afterItemID] else {
             specifiedItemIsNotFound(afterItemID, file: file, line: line)
         }
@@ -109,7 +109,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections[itemPosition.sectionIndex].elements.insert(contentsOf: items, at: itemIndex)
     }
 
-    func remove(itemIDs: [ItemID]) {
+    mutating func remove(itemIDs: [ItemID]) {
         let itemPositionMap = self.itemPositionMap()
         var removeIndexSetMap = [Int: IndexSet]()
 
@@ -128,13 +128,13 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         }
     }
 
-    func removeAllItems() {
+    mutating func removeAllItems() {
         for sectionIndex in sections.indices {
             sections[sectionIndex].elements.removeAll()
         }
     }
 
-    func move(itemID: ItemID, before beforeItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
+    mutating func move(itemID: ItemID, before beforeItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
         guard let removed = remove(itemID: itemID) else {
             specifiedItemIsNotFound(itemID, file: file, line: line)
         }
@@ -146,7 +146,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections[itemPosition.sectionIndex].elements.insert(removed, at: itemPosition.itemRelativeIndex)
     }
 
-    func move(itemID: ItemID, after afterItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
+    mutating func move(itemID: ItemID, after afterItemID: ItemID, file: StaticString = #file, line: UInt = #line) {
         guard let removed = remove(itemID: itemID) else {
             specifiedItemIsNotFound(itemID, file: file, line: line)
         }
@@ -159,7 +159,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections[itemPosition.sectionIndex].elements.insert(removed, at: itemIndex)
     }
 
-    func update(itemIDs: [ItemID], file: StaticString = #file, line: UInt = #line) {
+    mutating func update(itemIDs: [ItemID], file: StaticString = #file, line: UInt = #line) {
         let itemPositionMap = self.itemPositionMap()
 
         for itemID in itemIDs {
@@ -171,12 +171,12 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         }
     }
 
-    func append(sectionIDs: [SectionID]) {
+    mutating func append(sectionIDs: [SectionID]) {
         let newSections = sectionIDs.lazy.map(Section.init)
         sections.append(contentsOf: newSections)
     }
 
-    func insert(sectionIDs: [SectionID], before beforeSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
+    mutating func insert(sectionIDs: [SectionID], before beforeSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
         guard let sectionIndex = sectionIndex(of: beforeSectionID) else {
             specifiedSectionIsNotFound(beforeSectionID, file: file, line: line)
         }
@@ -185,7 +185,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections.insert(contentsOf: newSections, at: sectionIndex)
     }
 
-    func insert(sectionIDs: [SectionID], after afterSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
+    mutating func insert(sectionIDs: [SectionID], after afterSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
         guard let beforeIndex = sectionIndex(of: afterSectionID) else {
             specifiedSectionIsNotFound(afterSectionID, file: file, line: line)
         }
@@ -195,13 +195,13 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections.insert(contentsOf: newSections, at: sectionIndex)
     }
 
-    func remove(sectionIDs: [SectionID]) {
+    mutating func remove(sectionIDs: [SectionID]) {
         for sectionID in sectionIDs {
             remove(sectionID: sectionID)
         }
     }
 
-    func move(sectionID: SectionID, before beforeSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
+    mutating func move(sectionID: SectionID, before beforeSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
         guard let removed = remove(sectionID: sectionID) else {
             specifiedSectionIsNotFound(sectionID, file: file, line: line)
         }
@@ -213,7 +213,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections.insert(removed, at: sectionIndex)
     }
 
-    func move(sectionID: SectionID, after afterSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
+    mutating func move(sectionID: SectionID, after afterSectionID: SectionID, file: StaticString = #file, line: UInt = #line) {
         guard let removed = remove(sectionID: sectionID) else {
             specifiedSectionIsNotFound(sectionID, file: file, line: line)
         }
@@ -226,7 +226,7 @@ final class SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         sections.insert(removed, at: sectionIndex)
     }
 
-    func update(sectionIDs: [SectionID]) {
+    mutating func update(sectionIDs: [SectionID]) {
         for sectionID in sectionIDs {
             guard let sectionIndex = sectionIndex(of: sectionID) else {
                 continue
@@ -250,7 +250,7 @@ private extension SnapshotStructure {
     }
 
     @discardableResult
-    func remove(itemID: ItemID) -> Item? {
+    mutating func remove(itemID: ItemID) -> Item? {
         guard let itemPosition = itemPositionMap()[itemID] else {
             return nil
         }
@@ -259,7 +259,7 @@ private extension SnapshotStructure {
     }
 
     @discardableResult
-    func remove(sectionID: SectionID) -> Section? {
+    mutating func remove(sectionID: SectionID) -> Section? {
         guard let sectionIndex = sectionIndex(of: sectionID) else {
             return nil
         }

--- a/Tests/CocoaCollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CocoaCollectionViewDiffableDataSourceTests.swift
@@ -20,7 +20,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
             NSCollectionViewItem()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
 
         dataSource.apply(snapshot)
         XCTAssertEqual(collectionView.isPerformBatchUpdatesCalledCount, 0)
@@ -50,33 +50,36 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot1.sectionIdentifiers, [])
         XCTAssertEqual(snapshot1.itemIdentifiers, [])
 
-        dataSource.snapshot().appendSections([0, 1, 2])
-        let snapshot2 = dataSource.snapshot()
-        XCTAssertEqual(snapshot2.sectionIdentifiers, [])
-        XCTAssertEqual(snapshot2.itemIdentifiers, [])
+        var snapshot2 = dataSource.snapshot()
+        snapshot2.appendSections([0, 1, 2])
 
-        let snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
+        let snapshot3 = dataSource.snapshot()
+        XCTAssertEqual(snapshot3.sectionIdentifiers, [])
+        XCTAssertEqual(snapshot3.itemIdentifiers, [])
+
+        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
         snapshotToApply.appendSections([0, 1, 2])
         snapshotToApply.appendItems([0, 1, 2])
         dataSource.apply(snapshotToApply)
-
-        let snapshot3 = dataSource.snapshot()
-        XCTAssertEqual(snapshot3.sectionIdentifiers, [0, 1, 2])
-        XCTAssertEqual(snapshot3.itemIdentifiers, [0, 1, 2])
-
-        dataSource.snapshot().appendSections([3, 4, 5])
 
         let snapshot4 = dataSource.snapshot()
         XCTAssertEqual(snapshot4.sectionIdentifiers, [0, 1, 2])
         XCTAssertEqual(snapshot4.itemIdentifiers, [0, 1, 2])
 
-        snapshot4.appendSections([3, 4, 5])
-        snapshot4.appendItems([3, 4, 5])
-        dataSource.apply(snapshot4)
+        var snapshot5 = dataSource.snapshot()
+        snapshot5.appendSections([3, 4, 5])
 
-        let snapshot5 = dataSource.snapshot()
-        XCTAssertEqual(snapshot5.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
-        XCTAssertEqual(snapshot5.itemIdentifiers, [0, 1, 2, 3, 4, 5])
+        var snapshot6 = dataSource.snapshot()
+        XCTAssertEqual(snapshot6.sectionIdentifiers, [0, 1, 2])
+        XCTAssertEqual(snapshot6.itemIdentifiers, [0, 1, 2])
+
+        snapshot6.appendSections([3, 4, 5])
+        snapshot6.appendItems([3, 4, 5])
+        dataSource.apply(snapshot6)
+
+        let snapshot7 = dataSource.snapshot()
+        XCTAssertEqual(snapshot7.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
+        XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
     func testItemIdentifier() {
@@ -85,7 +88,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
             NSCollectionViewItem()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -100,7 +103,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
             NSCollectionViewItem()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -117,7 +120,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
 
         XCTAssertEqual(dataSource.numberOfSections(in: collectionView), 0)
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -131,7 +134,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
             NSCollectionViewItem()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -146,7 +149,7 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
             item
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)

--- a/Tests/CollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CollectionViewDiffableDataSourceTests.swift
@@ -20,7 +20,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             UICollectionViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
 
         dataSource.apply(snapshot)
         XCTAssertEqual(collectionView.isPerformBatchUpdatesCalledCount, 0)
@@ -50,33 +50,36 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot1.sectionIdentifiers, [])
         XCTAssertEqual(snapshot1.itemIdentifiers, [])
 
-        dataSource.snapshot().appendSections([0, 1, 2])
-        let snapshot2 = dataSource.snapshot()
-        XCTAssertEqual(snapshot2.sectionIdentifiers, [])
-        XCTAssertEqual(snapshot2.itemIdentifiers, [])
+        var snapshot2 = dataSource.snapshot()
+        snapshot2.appendSections([0, 1, 2])
 
-        let snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
+        let snapshot3 = dataSource.snapshot()
+        XCTAssertEqual(snapshot3.sectionIdentifiers, [])
+        XCTAssertEqual(snapshot3.itemIdentifiers, [])
+
+        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
         snapshotToApply.appendSections([0, 1, 2])
         snapshotToApply.appendItems([0, 1, 2])
         dataSource.apply(snapshotToApply)
-
-        let snapshot3 = dataSource.snapshot()
-        XCTAssertEqual(snapshot3.sectionIdentifiers, [0, 1, 2])
-        XCTAssertEqual(snapshot3.itemIdentifiers, [0, 1, 2])
-
-        dataSource.snapshot().appendSections([3, 4, 5])
 
         let snapshot4 = dataSource.snapshot()
         XCTAssertEqual(snapshot4.sectionIdentifiers, [0, 1, 2])
         XCTAssertEqual(snapshot4.itemIdentifiers, [0, 1, 2])
 
-        snapshot4.appendSections([3, 4, 5])
-        snapshot4.appendItems([3, 4, 5])
-        dataSource.apply(snapshot4)
+        var snapshot5 = dataSource.snapshot()
+        snapshot5.appendSections([3, 4, 5])
 
-        let snapshot5 = dataSource.snapshot()
-        XCTAssertEqual(snapshot5.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
-        XCTAssertEqual(snapshot5.itemIdentifiers, [0, 1, 2, 3, 4, 5])
+        var snapshot6 = dataSource.snapshot()
+        XCTAssertEqual(snapshot6.sectionIdentifiers, [0, 1, 2])
+        XCTAssertEqual(snapshot6.itemIdentifiers, [0, 1, 2])
+
+        snapshot6.appendSections([3, 4, 5])
+        snapshot6.appendItems([3, 4, 5])
+        dataSource.apply(snapshot6)
+
+        let snapshot7 = dataSource.snapshot()
+        XCTAssertEqual(snapshot7.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
+        XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
     func testItemIdentifier() {
@@ -85,7 +88,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             UICollectionViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -100,7 +103,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             UICollectionViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -117,7 +120,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
         XCTAssertEqual(dataSource.numberOfSections(in: collectionView), 0)
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -131,7 +134,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             UICollectionViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -146,7 +149,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             cell
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)

--- a/Tests/DiffableDataSourceTests.swift
+++ b/Tests/DiffableDataSourceTests.swift
@@ -16,7 +16,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.appendSections(test.append)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -33,7 +33,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.appendSections(test.append)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -51,7 +51,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -67,7 +67,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -86,7 +86,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -102,7 +102,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -122,7 +122,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.deleteSections(test.delete)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -140,7 +140,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.moveSection(test.move, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -158,7 +158,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.moveSection(test.move, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -194,7 +194,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
             snapshot.reloadSections(test.reload)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.initial)
@@ -213,7 +213,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.appendItems(test.append)
@@ -231,7 +231,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.appendItems(test.append)
@@ -253,7 +253,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items)
@@ -276,7 +276,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items)
@@ -302,7 +302,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, beforeItem: test.before)
@@ -320,7 +320,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, beforeItem: test.before)
@@ -341,7 +341,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, afterItem: test.after)
@@ -359,7 +359,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, afterItem: test.after)
@@ -382,7 +382,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -409,7 +409,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -435,7 +435,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -463,7 +463,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -539,7 +539,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -564,7 +564,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -583,7 +583,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -602,7 +602,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.numberOfSections, test.expected)
@@ -618,7 +618,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.numberOfSections, test.expected)
@@ -636,7 +636,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -655,7 +655,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -674,7 +674,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -690,7 +690,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -708,7 +708,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -727,7 +727,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -748,7 +748,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -767,7 +767,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -789,7 +789,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -808,7 +808,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -830,7 +830,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -849,7 +849,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -870,7 +870,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.indexOfSection(test.section), test.expectedIndex)
@@ -886,7 +886,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.indexOfSection(test.section), test.expectedIndex)

--- a/Tests/TableViewDiffableDataSourceTests.swift
+++ b/Tests/TableViewDiffableDataSourceTests.swift
@@ -20,7 +20,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             UITableViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
 
         dataSource.apply(snapshot)
         XCTAssertEqual(tableView.isPerformBatchUpdatesCalledCount, 0)
@@ -50,33 +50,36 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot1.sectionIdentifiers, [])
         XCTAssertEqual(snapshot1.itemIdentifiers, [])
 
-        dataSource.snapshot().appendSections([0, 1, 2])
-        let snapshot2 = dataSource.snapshot()
-        XCTAssertEqual(snapshot2.sectionIdentifiers, [])
-        XCTAssertEqual(snapshot2.itemIdentifiers, [])
+        var snapshot2 = dataSource.snapshot()
+        snapshot2.appendSections([0, 1, 2])
 
-        let snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
+        let snapshot3 = dataSource.snapshot()
+        XCTAssertEqual(snapshot3.sectionIdentifiers, [])
+        XCTAssertEqual(snapshot3.itemIdentifiers, [])
+
+        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
         snapshotToApply.appendSections([0, 1, 2])
         snapshotToApply.appendItems([0, 1, 2])
         dataSource.apply(snapshotToApply)
-
-        let snapshot3 = dataSource.snapshot()
-        XCTAssertEqual(snapshot3.sectionIdentifiers, [0, 1, 2])
-        XCTAssertEqual(snapshot3.itemIdentifiers, [0, 1, 2])
-
-        dataSource.snapshot().appendSections([3, 4, 5])
 
         let snapshot4 = dataSource.snapshot()
         XCTAssertEqual(snapshot4.sectionIdentifiers, [0, 1, 2])
         XCTAssertEqual(snapshot4.itemIdentifiers, [0, 1, 2])
 
-        snapshot4.appendSections([3, 4, 5])
-        snapshot4.appendItems([3, 4, 5])
-        dataSource.apply(snapshot4)
+        var snapshot5 = dataSource.snapshot()
+        snapshot5.appendSections([3, 4, 5])
 
-        let snapshot5 = dataSource.snapshot()
-        XCTAssertEqual(snapshot5.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
-        XCTAssertEqual(snapshot5.itemIdentifiers, [0, 1, 2, 3, 4, 5])
+        var snapshot6 = dataSource.snapshot()
+        XCTAssertEqual(snapshot6.sectionIdentifiers, [0, 1, 2])
+        XCTAssertEqual(snapshot6.itemIdentifiers, [0, 1, 2])
+
+        snapshot6.appendSections([3, 4, 5])
+        snapshot6.appendItems([3, 4, 5])
+        dataSource.apply(snapshot6)
+
+        let snapshot7 = dataSource.snapshot()
+        XCTAssertEqual(snapshot7.sectionIdentifiers, [0, 1, 2, 3, 4, 5])
+        XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
     func testItemIdentifier() {
@@ -85,7 +88,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             UITableViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -100,7 +103,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             UITableViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -117,7 +120,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
         XCTAssertEqual(dataSource.numberOfSections(in: tableView), 0)
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -131,7 +134,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             UITableViewCell()
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -146,7 +149,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             cell
         }
 
-        let snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)


### PR DESCRIPTION
In the latest Xcode 11 (beta 6), DiffableDataSourceSnapshot class changed to a struct.
This PR adopt the API to the latest UIKit's API.

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

If we can write `let snapshot` as before, we can't copy and paste as it is when we migrate to the iOS 13 standard API in the future. Because of `let snapshot` almost causes compilation error on in Cocoa's API.

## Impact on Existing Code

In most cases `let snapshot` is now a compilation error. Users should rewrite it to `var snapshot`.
