### PR TITLE
Add support for specifying section header and footer titles

### DIFF
--- a/Sources/UIKit/TableViewDiffableDataSource.swift
+++ b/Sources/UIKit/TableViewDiffableDataSource.swift
@@ -94,6 +94,28 @@ open class TableViewDiffableDataSource<SectionIdentifierType: Hashable, ItemIden
         return core.numberOfItems(inSection: section)
     }
 
+    /// Returns the title for the specified section's header.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - section: An index of section.
+    ///
+    /// - Returns: The title for the specified section's header, or `nil` for no title.
+    open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return nil
+    }
+
+    /// Returns the title for the specified section's footer.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - section: An index of section.
+    ///
+    /// - Returns: The title for the specified section's footer, or `nil` for no title.
+    open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return nil
+    }
+
     /// Returns a cell for row at specified index path.
     ///
     /// - Parameters:


### PR DESCRIPTION
This adds support for specifying section header and footer titles by subclassing TableViewDiffableDataSource, just like the official version. 

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
This adds default implementations for `tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)` and `tableView(_ tableView: UITableView, titleForFooterInSection section: Int)`, but leaving them as `open` functions, letting subclasses override their behaviour.

## Motivation and Context
When `UITableViewDiffableDataSource` was introduced, setting section header and footer titles was not supported. Support for this has since been added, so I thought it would be nice if this library was updated to mirror the official version.

## Impact on Existing Code
None
