### PR TITLE
[WIP] Completion Block for CollectionView and TableView DiffableDatasources

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "DifferenceKit",
-        "repositoryURL": "https://github.com/ra1028/DifferenceKit.git",
+        "repositoryURL": "https://github.com/serjooo/DifferenceKit.git",
         "state": {
           "branch": null,
-          "revision": "4eb31f8e85e4cb13732f9664d6e01e507cd592a0",
-          "version": "1.1.3"
+          "revision": "8e794f6ebb3f84ef69206700153540a38303df43",
+          "version": "1.1.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "DiffableDataSources", targets: ["DiffableDataSources"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ra1028/DifferenceKit.git", .upToNextMinor(from: "1.1.0"))
+        .package(url: "https://github.com/serjooo/DifferenceKit.git", .upToNextMinor(from: "1.1.5"))
     ],
     targets: [
         .target(

--- a/Sources/UIKit/CollectionViewDiffableDataSource.swift
+++ b/Sources/UIKit/CollectionViewDiffableDataSource.swift
@@ -39,7 +39,9 @@ open class CollectionViewDiffableDataSource<SectionIdentifierType: Hashable, Ite
     ///   - snapshot: A snapshot object to be applied to data model.
     ///   - animatingDifferences: A Boolean value indicating whether to update with
     ///                           diffing animation.
-    public func apply(_ snapshot: DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>, animatingDifferences: Bool = true) {
+    ///   - completion: An optional completion block which is called when the UICollectionView
+    ///                 completes performing updates.
+    public func apply(_ snapshot: DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>, animatingDifferences: Bool = true, completion: (() -> Void)? = nil) {
         core.apply(
             snapshot,
             view: collectionView,

--- a/Sources/UIKit/CollectionViewDiffableDataSource.swift
+++ b/Sources/UIKit/CollectionViewDiffableDataSource.swift
@@ -47,7 +47,7 @@ open class CollectionViewDiffableDataSource<SectionIdentifierType: Hashable, Ite
             view: collectionView,
             animatingDifferences: animatingDifferences,
             performUpdates: { collectionView, changeset, setSections in
-                collectionView.reload(using: changeset, setData: setSections)
+                collectionView.reload(using: changeset, setData: setSections, completion: completion)
         })
     }
 

--- a/Sources/UIKit/TableViewDiffableDataSource.swift
+++ b/Sources/UIKit/TableViewDiffableDataSource.swift
@@ -44,7 +44,7 @@ open class TableViewDiffableDataSource<SectionIdentifierType: Hashable, ItemIden
             view: tableView,
             animatingDifferences: animatingDifferences,
             performUpdates: { tableView, changeset, setSections in
-                tableView.reload(using: changeset, with: self.defaultRowAnimation, setData: setSections)
+                tableView.reload(using: changeset, with: self.defaultRowAnimation, setData: setSections, completion: completion)
         })
     }
 

--- a/Sources/UIKit/TableViewDiffableDataSource.swift
+++ b/Sources/UIKit/TableViewDiffableDataSource.swift
@@ -36,7 +36,9 @@ open class TableViewDiffableDataSource<SectionIdentifierType: Hashable, ItemIden
     ///   - snapshot: A snapshot object to be applied to data model.
     ///   - animatingDifferences: A Boolean value indicating whether to update with
     ///                           diffing animation.
-    public func apply(_ snapshot: DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>, animatingDifferences: Bool = true) {
+    ///   - completion: An optional completion block which is called when the UITableView
+    ///                 completes performing updates.
+    public func apply(_ snapshot: DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>, animatingDifferences: Bool = true, completion: (() -> Void)? = nil) {
         core.apply(
             snapshot,
             view: tableView,


### PR DESCRIPTION
## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
This library provides a back port to `UITableViewDiffableDataSource`, `UICollectionViewDiffableDataSource`, and `NSCollectionViewDiffableDataSource` and tries to stay as close to the API as possible. 

However, one part of the API is missing for `UICollectionView` and `UITableView` that does not exist for `NSCollectionView` which is the `Completio` block of applying the difference. 

`UIKIt`: `apply(_:animatingDifferences:completion:)`
`AppKit`: `applySnapshot:animatingDifferences:`

However, to achieve this we would need to change the internals of `DifferenceKit` on the `reload` method to accept a `completion` block and call it once it is done applying the difference.

## Motivation and Context
By providing a `completion` on `apply` method, the API will be exactly as Apple's APIs. 

## Impact on Existing Code
As Apple's API `completion` block is optional, the function parameter could default to `nil` and this will not effect the client code and will not cause any breaking changes.
