### PR TITLE
Updates git submodule.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ra1028/DifferenceKit" "1.1.3"
+github "ra1028/DifferenceKit" "1.1.4"

--- a/Examples/Example-iOS/InsertionSortViewController.swift
+++ b/Examples/Example-iOS/InsertionSortViewController.swift
@@ -107,7 +107,7 @@ final class InsertionSortViewController: UIViewController {
     }
 
     func randmize(animated: Bool) {
-        let snapshot = DiffableDataSourceSnapshot<Section, Node>()
+        var snapshot = DiffableDataSourceSnapshot<Section, Node>()
         let rows = Int(collectionView.bounds.height / nodeSize.height) - 1
         let columns = Int(collectionView.bounds.width / nodeSize.width)
 
@@ -126,7 +126,7 @@ final class InsertionSortViewController: UIViewController {
         }
 
         var isNextSortRequired = false
-        let snapshot = dataSource.snapshot()
+        var snapshot = dataSource.snapshot()
 
         for section in snapshot.sectionIdentifiers where !section.isSorted {
             section.sortNext()

--- a/Examples/Example-iOS/MountainsViewController.swift
+++ b/Examples/Example-iOS/MountainsViewController.swift
@@ -50,7 +50,7 @@ final class MountainsViewController: UIViewController {
             .filter { $0.contains(filter) }
             .sorted { $0.name < $1.name }
 
-        let snapshot = DiffableDataSourceSnapshot<Section, Mountain>()
+        var snapshot = DiffableDataSourceSnapshot<Section, Mountain>()
         snapshot.appendSections([.main])
         snapshot.appendItems(mountains)
         dataSource.apply(snapshot)

--- a/Examples/Example-iOS/TopViewController.swift
+++ b/Examples/Example-iOS/TopViewController.swift
@@ -42,7 +42,7 @@ final class TopViewController: UIViewController {
     }
 
     func reset() {
-        let snapshot = DiffableDataSourceSnapshot<Section, Item>()
+        var snapshot = DiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([.main])
         snapshot.appendItems([.mountains, .insertionSort])
         dataSource.apply(snapshot)


### PR DESCRIPTION
A recent update to DifferenceKit causes projects that depend on DiffableDataSources to throw a runtime error if the dependencies are built with Carthage. Namely:
dyld: Symbol not found: _$s13DifferenceKit14DifferentiableMp

This PR updates the DifferenceKit submodule embedded in DiffableDataSources in an attempt to solve this issue.