### PR TITLE
Add update and move support

### DIFF
--- a/Sources/Internal/DiffableDataSourceCore.swift
+++ b/Sources/Internal/DiffableDataSourceCore.swift
@@ -68,7 +68,7 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
             return nil
         }
 
-        return items[indexPath.item].identifier
+        return items[indexPath.item].contentIdentifier
     }
 
     func unsafeItemIdentifier(for indexPath: IndexPath, file: StaticString = #file, line: UInt = #line) -> ItemIdentifierType {
@@ -83,7 +83,7 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
         let indexPathMap: [ItemIdentifierType: IndexPath] = sections.enumerated()
             .reduce(into: [:]) { result, section in
                 for (itemIndex, item) in section.element.elements.enumerated() {
-                    result[item.identifier] = IndexPath(
+                    result[item.contentIdentifier] = IndexPath(
                         item: itemIndex,
                         section: section.offset
                     )

--- a/Sources/Internal/DiffableDataSourceCore.swift
+++ b/Sources/Internal/DiffableDataSourceCore.swift
@@ -68,7 +68,7 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
             return nil
         }
 
-        return items[indexPath.item].differenceIdentifier
+        return items[indexPath.item].identifier
     }
 
     func unsafeItemIdentifier(for indexPath: IndexPath, file: StaticString = #file, line: UInt = #line) -> ItemIdentifierType {
@@ -83,7 +83,7 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
         let indexPathMap: [ItemIdentifierType: IndexPath] = sections.enumerated()
             .reduce(into: [:]) { result, section in
                 for (itemIndex, item) in section.element.elements.enumerated() {
-                    result[item.differenceIdentifier] = IndexPath(
+                    result[item.identifier] = IndexPath(
                         item: itemIndex,
                         section: section.offset
                     )

--- a/Sources/Internal/SnapshotStructure.swift
+++ b/Sources/Internal/SnapshotStructure.swift
@@ -3,11 +3,13 @@ import DifferenceKit
 
 struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
     struct Item: Differentiable, Equatable {
-        var differenceIdentifier: ItemID
+        var differenceIdentifier: Int
+        var identifier: ItemID
         var isReloaded: Bool
 
         init(id: ItemID, isReloaded: Bool) {
-            self.differenceIdentifier = id
+            self.identifier = id
+            self.differenceIdentifier = id.hashValue
             self.isReloaded = isReloaded
         }
 
@@ -16,7 +18,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         }
 
         func isContentEqual(to source: Item) -> Bool {
-            return !isReloaded && differenceIdentifier == source.differenceIdentifier
+            return !isReloaded && identifier == source.identifier
         }
     }
 
@@ -53,7 +55,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
     var allItemIDs: [ItemID] {
         return sections.lazy
             .flatMap { $0.elements }
-            .map { $0.differenceIdentifier }
+            .map { $0.identifier }
     }
 
     func items(in sectionID: SectionID, file: StaticString = #file, line: UInt = #line) -> [ItemID] {
@@ -61,7 +63,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
             specifiedSectionIsNotFound(sectionID, file: file, line: line)
         }
 
-        return sections[sectionIndex].elements.map { $0.differenceIdentifier }
+        return sections[sectionIndex].elements.map { $0.identifier }
     }
 
     func section(containing itemID: ItemID) -> SectionID? {
@@ -270,7 +272,7 @@ private extension SnapshotStructure {
     func itemPositionMap() -> [ItemID: ItemPosition] {
         return sections.enumerated().reduce(into: [:]) { result, section in
             for (itemRelativeIndex, item) in section.element.elements.enumerated() {
-                result[item.differenceIdentifier] = ItemPosition(
+                result[item.identifier] = ItemPosition(
                     item: item,
                     itemRelativeIndex: itemRelativeIndex,
                     section: section.element,

--- a/Sources/Internal/SnapshotStructure.swift
+++ b/Sources/Internal/SnapshotStructure.swift
@@ -4,11 +4,11 @@ import DifferenceKit
 struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
     struct Item: Differentiable, Equatable {
         var differenceIdentifier: Int
-        var identifier: ItemID
+        var contentIdentifier: ItemID
         var isReloaded: Bool
 
         init(id: ItemID, isReloaded: Bool) {
-            self.identifier = id
+            self.contentIdentifier = id
             self.differenceIdentifier = id.hashValue
             self.isReloaded = isReloaded
         }
@@ -18,7 +18,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
         }
 
         func isContentEqual(to source: Item) -> Bool {
-            return !isReloaded && identifier == source.identifier
+            return !isReloaded && contentIdentifier == source.contentIdentifier
         }
     }
 
@@ -55,7 +55,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
     var allItemIDs: [ItemID] {
         return sections.lazy
             .flatMap { $0.elements }
-            .map { $0.identifier }
+            .map { $0.contentIdentifier }
     }
 
     func items(in sectionID: SectionID, file: StaticString = #file, line: UInt = #line) -> [ItemID] {
@@ -63,7 +63,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
             specifiedSectionIsNotFound(sectionID, file: file, line: line)
         }
 
-        return sections[sectionIndex].elements.map { $0.identifier }
+        return sections[sectionIndex].elements.map { $0.contentIdentifier }
     }
 
     func section(containing itemID: ItemID) -> SectionID? {
@@ -272,7 +272,7 @@ private extension SnapshotStructure {
     func itemPositionMap() -> [ItemID: ItemPosition] {
         return sections.enumerated().reduce(into: [:]) { result, section in
             for (itemRelativeIndex, item) in section.element.elements.enumerated() {
-                result[item.identifier] = ItemPosition(
+                result[item.contentIdentifier] = ItemPosition(
                     item: item,
                     itemRelativeIndex: itemRelativeIndex,
                     section: section.element,


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests (N/A)
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
The current code was not correctly leveraging `DifferenceKit` to address moves and updates. In particular, it was not distinguishing **changes in content** versus changes in the **identifier**.  

This code change ensures that the difference identifier is no longer of the whole `Item`, but instead just the hashValue of the `Item` (as determined by the implemention of `Item`.) 

For a visualization of the difference, please see the below gifs (the example iOS code in this repo was slightly modified to illustrate this).

For a clear conceptual example of the correction that this pull request sets out to accomplish, consider if `Item` was the following:
```swift
struct person: Hashable {
    var birthName : String  // Assume this is our unique identifier for a person.
    var age : Int
    func hash(into hasher: inout Hasher) {
            hasher.combine(birthName)
   }
}
```
And we had to compare the datasource diff of the following lists (being used as datasource updates for a collectionview):
Source: `[(birthName: "Andy", age: 15), (birthName: "Kevin", age: 16)]`  
Target:  `[(birthName: "Kevin", age: 16)]` 

**Without** the change in this pull request, we get 2 deletions and 1 insertion (animated as such)

**With** this change in this PR , we get 1 deletion and 1 update (correctly animated).

## Related Issue
N/A

## Motivation and Context
The motivation was for a better, and more correct, diff animation.

## Impact on Existing Code
None beyond what is described.

## Screenshots
Notice the "move" animations that occur in **after** that do not happen in **before**


**Before:**
![Before](https://user-images.githubusercontent.com/8174310/74995346-7b64e180-5405-11ea-837f-6c60fd8b220e.gif)

**After:**
![after](https://user-images.githubusercontent.com/8174310/74995354-815ac280-5405-11ea-802b-f608ed7f0e31.gif)
