### PR TITLE
Add default implementation for other UITableViewDelegate/UICollectionViewDelegate methods

### DIFF
--- a/Sources/Internal/SnapshotStructure.swift
+++ b/Sources/Internal/SnapshotStructure.swift
@@ -35,7 +35,7 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
             self.init(id: id, items: [], isReloaded: false)
         }
 
-        init<C: Collection>(source: Section, elements: C) where C.Element == Item {
+        init<C: Swift.Collection>(source: Section, elements: C) where C.Element == Item {
             self.init(id: source.differenceIdentifier, items: Array(elements), isReloaded: source.isReloaded)
         }
 

--- a/Sources/UIKit/CollectionViewDiffableDataSource.swift
+++ b/Sources/UIKit/CollectionViewDiffableDataSource.swift
@@ -132,6 +132,29 @@ open class CollectionViewDiffableDataSource<SectionIdentifierType: Hashable, Ite
 
         return view
     }
+
+    /// Returns whether it is possible to edit a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - collectionView: A collection view instance managed by `self`.
+    ///   - section: An index of section.
+    ///
+    /// - Returns: A boolean for row at specified index path.
+    open func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    /// Moves a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - collectionView: A collection view instance managed by `self`.
+    ///   - sourceIndexPath: An index path for given cell position.
+    ///   - destinationIndexPath: An index path for target cell position.
+    ///
+    /// - Returns: Void.
+    public func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        // Empty implementation.
+    }
 }
 
 #endif

--- a/Sources/UIKit/TableViewDiffableDataSource.swift
+++ b/Sources/UIKit/TableViewDiffableDataSource.swift
@@ -135,6 +135,56 @@ open class TableViewDiffableDataSource<SectionIdentifierType: Hashable, ItemIden
 
         return cell
     }
+
+    /// Returns whether it is possible to edit a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - section: An index of section.
+    ///
+    /// - Returns: A boolean for row at specified index path.
+    open func tableView(_ tableView: UITableView, canEditRowAt: IndexPath) -> Bool {
+        return false
+    }
+
+    /// Returns whether it is possible to move a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - section: An index of section.
+    ///
+    /// - Returns: A boolean for row at specified index path.
+    open func tableView(_ tableView: UITableView, canMoveRowAt _: IndexPath) -> Bool {
+        return false
+    }
+
+    /// Performs the edit action for a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - editingStyle: An action for given edit action.
+    ///   - indexPath: An index path for cell.
+    ///
+    /// - Returns: Void.
+    open func tableView(_ tableView: UITableView, commit _: UITableViewCell.EditingStyle, forRowAt _: IndexPath) {
+        // Empty implementation.
+    }
+
+    /// Moves a row at given index path.
+    ///
+    /// - Parameters:
+    ///   - tableView: A table view instance managed by `self`.
+    ///   - source: An index path for given cell position.
+    ///   - target: An index path for target cell position.
+    ///
+    /// - Returns: Void.
+    open func tableView(_ tableView: UITableView, moveRowAt _: IndexPath, to _: IndexPath) {
+        // Empty implementation.
+    }
+
+    open func tableView(_ tableView: UITableView, sectionForSectionIndexTitle _: String, at section: Int) -> Int {
+        return section
+    }
 }
 
 #endif

--- a/Tests/CollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CollectionViewDiffableDataSourceTests.swift
@@ -167,6 +167,24 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
             cell
         )
     }
+
+    func testCanMoveRowAt() {
+        let collectionView = MockCollectionView()
+        let cell = UICollectionViewCell()
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+            cell
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([0, 1, 2])
+        snapshot.appendItems([0, 1, 2], toSection: 0)
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(
+            dataSource.collectionView(collectionView, canMoveItemAt: IndexPath(item: 1, section: 0)),
+            false
+        )
+    }
 }
 
 final class MockCollectionView: UICollectionView {

--- a/Tests/TableViewDiffableDataSourceTests.swift
+++ b/Tests/TableViewDiffableDataSourceTests.swift
@@ -167,6 +167,42 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
             cell
         )
     }
+
+    func testCanEditRowAt() {
+        let tableView = MockTableView()
+        let cell = UITableViewCell()
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+            cell
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([0, 1, 2])
+        snapshot.appendItems([0, 1, 2], toSection: 0)
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(
+            dataSource.tableView(tableView, canEditRowAt: IndexPath(item: 1, section: 0)),
+            false
+        )
+    }
+
+    func testCanMoveRowAt() {
+        let tableView = MockTableView()
+        let cell = UITableViewCell()
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+            cell
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([0, 1, 2])
+        snapshot.appendItems([0, 1, 2], toSection: 0)
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(
+            dataSource.tableView(tableView, canMoveRowAt: IndexPath(item: 1, section: 0)),
+            false
+        )
+    }
 }
 
 final class MockTableView: UITableView {


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description

As per #16 , when implementing a table view delegate there are currently some methods that aren't implemented. It is currently possible to add these methods by using `@objc(…)` modifier, but I feel like a default, open for overriding implementation achieves a better experience after all.

## Related Issue

Introduction of default implementations for other `UITableViewDelegate` and `UICollectionViewDelegate` methods -  #16 

## Impact on Existing Code

No impact on existing code.
