### PR TITLE
Optimize numberOfItems and numberOfSections in snapshot

### DIFF
--- a/Sources/DiffableDataSourceSnapshot.swift
+++ b/Sources/DiffableDataSourceSnapshot.swift
@@ -8,12 +8,16 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
 
     /// The number of item identifiers in the snapshot.
     public var numberOfItems: Int {
-        return itemIdentifiers.count
+        var count = 0
+        for section in structure.sections {
+            count += numberOfItems(inSection: section.differenceIdentifier)
+        }
+        return count
     }
 
     /// The number of section identifiers in the snapshot.
     public var numberOfSections: Int {
-        return sectionIdentifiers.count
+        return structure.sections.count
     }
 
     /// All section identifiers in the snapshot.
@@ -33,7 +37,7 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: The number of item identifiers in the specified section.
     public func numberOfItems(inSection identifier: SectionIdentifierType) -> Int {
-        return itemIdentifiers(inSection: identifier).count
+        return structure.numberOfItems(in: identifier)
     }
 
     /// Returns the item identifiers in the specified section.

--- a/Sources/Internal/SnapshotStructure.swift
+++ b/Sources/Internal/SnapshotStructure.swift
@@ -56,6 +56,14 @@ struct SnapshotStructure<SectionID: Hashable, ItemID: Hashable> {
             .map { $0.differenceIdentifier }
     }
 
+    func numberOfItems(in sectionID: SectionID, file: StaticString = #file, line: UInt = #line) -> Int {
+        guard let sectionIndex = sectionIndex(of: sectionID) else {
+            specifiedSectionIsNotFound(sectionID, file: file, line: line)
+        }
+
+        return sections[sectionIndex].elements.count
+    }
+
     func items(in sectionID: SectionID, file: StaticString = #file, line: UInt = #line) -> [ItemID] {
         guard let sectionIndex = sectionIndex(of: sectionID) else {
             specifiedSectionIsNotFound(sectionID, file: file, line: line)


### PR DESCRIPTION
This avoids creating the intermediate collections to get these values

## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
