### PR TITLE
Fix compile error of sample mac application

### DIFF
--- a/Examples/Example-macOS/MountainsViewController.swift
+++ b/Examples/Example-macOS/MountainsViewController.swift
@@ -49,7 +49,7 @@ final class MountainsViewController: NSViewController {
             .filter { $0.contains(filter) }
             .sorted { $0.name < $1.name }
 
-        let snapshot = DiffableDataSourceSnapshot<Section, Mountain>()
+        var snapshot = DiffableDataSourceSnapshot<Section, Mountain>()
         snapshot.appendSections([.main])
         snapshot.appendItems(mountains)
         dataSource.apply(snapshot)


### PR DESCRIPTION
## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
At https://github.com/ra1028/DiffableDataSources/pull/3 , DiffableDataSourceSnapshot gets to struct but the example code was not fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ra1028/DiffableDataSources/issues/26

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We cannot compile `Example-macOS` target.

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
