### PR TITLE
Added sectionIdentifier(for:) method for data sources

### DIFF
--- a/Sources/AppKit/CocoaCollectionViewDiffableDataSource.swift
+++ b/Sources/AppKit/CocoaCollectionViewDiffableDataSource.swift
@@ -54,6 +54,16 @@ open class CocoaCollectionViewDiffableDataSource<SectionIdentifierType: Hashable
         return core.snapshot()
     }
 
+    /// Returns an section identifier for given section index.
+    ///
+    /// - Parameters:
+    ///   - section: An section index for the section identifier.
+    ///
+    /// - Returns: An section identifier for given section index.
+    public func sectionIdentifier(for section: Int) -> SectionIdentifierType? {
+        return core.sectionIdentifier(for: section)
+    }
+
     /// Returns an item identifier for given index path.
     ///
     /// - Parameters:

--- a/Sources/Internal/DiffableDataSourceCore.swift
+++ b/Sources/Internal/DiffableDataSourceCore.swift
@@ -57,6 +57,14 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
         return snapshot
     }
 
+    func sectionIdentifier(for section: Int) -> SectionIdentifierType? {
+        guard 0..<sections.endIndex ~= section else {
+            return nil
+        }
+
+        return sections[section].differenceIdentifier
+    }
+
     func itemIdentifier(for indexPath: IndexPath) -> ItemIdentifierType? {
         guard 0..<sections.endIndex ~= indexPath.section else {
             return nil

--- a/Sources/UIKit/CollectionViewDiffableDataSource.swift
+++ b/Sources/UIKit/CollectionViewDiffableDataSource.swift
@@ -60,6 +60,16 @@ open class CollectionViewDiffableDataSource<SectionIdentifierType: Hashable, Ite
         return core.snapshot()
     }
 
+    /// Returns an section identifier for given section index.
+    ///
+    /// - Parameters:
+    ///   - section: An section index for the section identifier.
+    ///
+    /// - Returns: An section identifier for given section index.
+    public func sectionIdentifier(for section: Int) -> SectionIdentifierType? {
+        return core.sectionIdentifier(for: section)
+    }
+
     /// Returns an item identifier for given index path.
     ///
     /// - Parameters:

--- a/Sources/UIKit/TableViewDiffableDataSource.swift
+++ b/Sources/UIKit/TableViewDiffableDataSource.swift
@@ -57,6 +57,16 @@ open class TableViewDiffableDataSource<SectionIdentifierType: Hashable, ItemIden
         return core.snapshot()
     }
 
+    /// Returns an section identifier for given section index.
+    ///
+    /// - Parameters:
+    ///   - section: An section index for the section identifier.
+    ///
+    /// - Returns: An section identifier for given section index.
+    public func sectionIdentifier(for section: Int) -> SectionIdentifierType? {
+        return core.sectionIdentifier(for: section)
+    }
+
     /// Returns an item identifier for given index path.
     ///
     /// - Parameters:

--- a/Tests/CocoaCollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CocoaCollectionViewDiffableDataSourceTests.swift
@@ -90,6 +90,20 @@ final class CocoaCollectionViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
+    func testSectionIdentifier() {
+        let collectionView = MockCollectionView()
+        let dataSource = CocoaCollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+            NSCollectionViewItem()
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([10, 20, 30])
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 1), 20)
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 100), nil)
+    }
+
     func testItemIdentifier() {
         let collectionView = MockCollectionView()
         let dataSource = CocoaCollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in

--- a/Tests/CollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CollectionViewDiffableDataSourceTests.swift
@@ -90,6 +90,20 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
+    func testSectionIdentifier() {
+        let collectionView = MockCollectionView()
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+            UICollectionViewCell()
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([10, 20, 30])
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 1), 20)
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 100), nil)
+    }
+
     func testItemIdentifier() {
         let collectionView = MockCollectionView()
         let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in

--- a/Tests/TableViewDiffableDataSourceTests.swift
+++ b/Tests/TableViewDiffableDataSourceTests.swift
@@ -90,6 +90,20 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot7.itemIdentifiers, [0, 1, 2, 3, 4, 5])
     }
 
+    func testSectionIdentifier() {
+        let tableView = MockTableView()
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+            UITableViewCell()
+        }
+
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        snapshot.appendSections([10, 20, 30])
+        dataSource.apply(snapshot)
+
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 1), 20)
+        XCTAssertEqual(dataSource.sectionIdentifier(for: 100), nil)
+    }
+
     func testItemIdentifier() {
         let tableView = MockTableView()
         let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in


### PR DESCRIPTION
## Checklist
- [YES] All tests are passed.  
- [YES] Added tests.  
- [YES] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [YES] Searched existing pull requests for ensure not duplicated.  

## Description
Added method `sectionIdentifier(for section: Int) -> SectionIdentifierType` for data sources.

## Related Issue
https://github.com/ra1028/DiffableDataSources/issues/33
