### PR TITLE
Support for ARM64 Macs

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ra1028/DifferenceKit" ~> 1.1
+github "ra1028/DifferenceKit" ~> 1.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ra1028/DifferenceKit" "1.1.4"
+github "ra1028/DifferenceKit" "1.2.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ra1028/DifferenceKit.git",
         "state": {
           "branch": null,
-          "revision": "4eb31f8e85e4cb13732f9664d6e01e507cd592a0",
-          "version": "1.1.3"
+          "revision": "62745d7780deef4a023a792a1f8f763ec7bf9705",
+          "version": "1.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "DiffableDataSources", targets: ["DiffableDataSources"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ra1028/DifferenceKit.git", .upToNextMinor(from: "1.1.0"))
+        .package(url: "https://github.com/ra1028/DifferenceKit.git", .upToNextMinor(from: "1.2.0"))
     ],
     targets: [
         .target(

--- a/XCConfigs/DiffableDataSources.xcconfig
+++ b/XCConfigs/DiffableDataSources.xcconfig
@@ -5,11 +5,11 @@ TVOS_DEPLOYMENT_TARGET = 9.0
 SDKROOT = 
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3
-VALID_ARCHS[sdk=macosx*] = i386 x86_64
+VALID_ARCHS[sdk=macosx*] = arm64 i386 x86_64
 VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*] = i386 x86_64
+VALID_ARCHS[sdk=iphonesimulator*] = arm64 i386 x86_64
 VALID_ARCHS[sdk=appletv*] = arm64
-VALID_ARCHS[sdk=appletvsimulator*] = x86_64
+VALID_ARCHS[sdk=appletvsimulator*] = arm64 x86_64
 
 CODE_SIGN_IDENTITY =
 CODE_SIGN_STYLE = Manual


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched existing pull requests for ensure not duplicated.  

## Description

Similarly to ra1028/DifferenceKit#124, this makes sure the project gets built for ARM64.
That requires DifferenceKit 1.2.0 so I updated the dependencies to DifferenceKit.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#36

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
