### PR TITLE
Uses native implementation when available

### DIFF
--- a/DiffableDataSources.xcodeproj/xcshareddata/xcschemes/DiffableDataSources.xcscheme
+++ b/DiffableDataSources.xcodeproj/xcshareddata/xcschemes/DiffableDataSources.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6BB762CB22B455170050DC03"
+            BuildableName = "DiffableDataSources.framework"
+            BlueprintName = "DiffableDataSources"
+            ReferencedContainer = "container:DiffableDataSources.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6BB762CB22B455170050DC03"
-            BuildableName = "DiffableDataSources.framework"
-            BlueprintName = "DiffableDataSources"
-            ReferencedContainer = "container:DiffableDataSources.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:DiffableDataSources.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/DiffableDataSourceSnapshot.swift
+++ b/Sources/DiffableDataSourceSnapshot.swift
@@ -1,28 +1,71 @@
+import UIKit
+
 /// A class for backporting `NSDiffableDataSourceSnapshot` introduced in iOS 13.0+, macOS 10.15+, tvOS 13.0+.
 /// Represents the mutable state of diffable data source of UI.
 public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemIdentifierType: Hashable> {
     internal var structure = SnapshotStructure<SectionIdentifierType, ItemIdentifierType>()
 
+    private let forceFallback: Bool
+    private var _nativeSnapshot: Any?
+    @available(iOS 13.0, *)
+    internal var nativeSnapshot: NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> {
+        get {
+            return _nativeSnapshot as! NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>
+        }
+        set {
+            _nativeSnapshot = newValue
+        }
+    }
+
     /// Creates a new empty snapshot object.
-    public init() {}
+    public init() {
+        self.init(forceFallback: false)
+    }
+
+    internal init(forceFallback: Bool) {
+        self.forceFallback = forceFallback
+        if #available(iOS 13.0, *), !forceFallback {
+            nativeSnapshot = .init()
+            return
+        }
+    }
+
+    @available(iOS 13.0, *)
+    static func from(nativeSnapshot: NSDiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>) -> Self {
+        var snapshot = DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>()
+        snapshot.nativeSnapshot = nativeSnapshot
+        return snapshot
+    }
 
     /// The number of item identifiers in the snapshot.
     public var numberOfItems: Int {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.numberOfItems
+        }
         return itemIdentifiers.count
     }
 
     /// The number of section identifiers in the snapshot.
     public var numberOfSections: Int {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.numberOfSections
+        }
         return sectionIdentifiers.count
     }
 
     /// All section identifiers in the snapshot.
     public var sectionIdentifiers: [SectionIdentifierType] {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.sectionIdentifiers
+        }
         return structure.allSectionIDs
     }
 
     /// All item identifiers in the snapshot.
     public var itemIdentifiers: [ItemIdentifierType] {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.itemIdentifiers
+        }
         return structure.allItemIDs
     }
 
@@ -33,6 +76,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: The number of item identifiers in the specified section.
     public func numberOfItems(inSection identifier: SectionIdentifierType) -> Int {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.numberOfItems(inSection: identifier)
+        }
         return itemIdentifiers(inSection: identifier).count
     }
 
@@ -43,6 +89,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: The item identifiers in the specified section.
     public func itemIdentifiers(inSection identifier: SectionIdentifierType) -> [ItemIdentifierType] {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.itemIdentifiers(inSection: identifier)
+        }
         return structure.items(in: identifier)
     }
 
@@ -53,6 +102,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: A section identifier containing the specified item.
     public func sectionIdentifier(containingItem identifier: ItemIdentifierType) -> SectionIdentifierType? {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.sectionIdentifier(containingItem: identifier)
+        }
         return structure.section(containing: identifier)
     }
 
@@ -63,6 +115,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: An index of the specified item.
     public func indexOfItem(_ identifier: ItemIdentifierType) -> Int? {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.indexOfItem(identifier)
+        }
         return itemIdentifiers.firstIndex { $0.isEqualHash(to: identifier) }
     }
 
@@ -73,6 +128,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///
     /// - Returns: An index of the specified section.
     public func indexOfSection(_ identifier: SectionIdentifierType) -> Int? {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.indexOfSection(identifier)
+        }
         return sectionIdentifiers.firstIndex { $0.isEqualHash(to: identifier) }
     }
 
@@ -82,6 +140,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifiers: The item identifiers to be appended.
     ///   - sectionIdentifier: An identifier of section to append the given identiciers.
     public mutating func appendItems(_ identifiers: [ItemIdentifierType], toSection sectionIdentifier: SectionIdentifierType? = nil) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.appendItems(identifiers, toSection: sectionIdentifier)
+        }
         structure.append(itemIDs: identifiers, to: sectionIdentifier)
     }
 
@@ -91,6 +152,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifiers: The item identifiers to be inserted.
     ///   - beforeIdentifier: An identifier of item.
     public mutating func insertItems(_ identifiers: [ItemIdentifierType], beforeItem beforeIdentifier: ItemIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.insertItems(identifiers, beforeItem: beforeIdentifier)
+        }
         structure.insert(itemIDs: identifiers, before: beforeIdentifier)
     }
 
@@ -100,6 +164,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifiers: The item identifiers to be inserted.
     ///   - afterIdentifier: An identifier of item.
     public mutating func insertItems(_ identifiers: [ItemIdentifierType], afterItem afterIdentifier: ItemIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.insertItems(identifiers, afterItem: afterIdentifier)
+        }
         structure.insert(itemIDs: identifiers, after: afterIdentifier)
     }
 
@@ -108,11 +175,17 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     /// - Parameters:
     ///   - identifiers: The item identifiers to be deleted.
     public mutating func deleteItems(_ identifiers: [ItemIdentifierType]) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.deleteItems(identifiers)
+        }
         structure.remove(itemIDs: identifiers)
     }
 
     /// Deletes the all items in the snapshot.
     public mutating func deleteAllItems() {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.deleteAllItems()
+        }
         structure.removeAllItems()
     }
 
@@ -122,6 +195,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifier: An item identifier to be moved.
     ///   - toIdentifier: An identifier of item.
     public mutating func moveItem(_ identifier: ItemIdentifierType, beforeItem toIdentifier: ItemIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.moveItem(identifier, beforeItem: toIdentifier)
+        }
         structure.move(itemID: identifier, before: toIdentifier)
     }
 
@@ -131,6 +207,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifier: An item identifier to be moved.
     ///   - toIdentifier: An identifier of item.
     public mutating func moveItem(_ identifier: ItemIdentifierType, afterItem toIdentifier: ItemIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.moveItem(identifier, afterItem: toIdentifier)
+        }
         structure.move(itemID: identifier, after: toIdentifier)
     }
 
@@ -139,6 +218,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     /// - Parameters:
     ///   - identifiers: The item identifiers to be reloaded.
     public mutating func reloadItems(_ identifiers: [ItemIdentifierType]) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.reloadItems(identifiers)
+        }
         structure.update(itemIDs: identifiers)
     }
 
@@ -147,6 +229,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     /// - Parameters:
     ///   - identifiers: The section identifiers to be appended.
     public mutating func appendSections(_ identifiers: [SectionIdentifierType]) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.appendSections(identifiers)
+        }
         structure.append(sectionIDs: identifiers)
     }
 
@@ -156,6 +241,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifiers: The section identifiers to be inserted.
     ///   - toIdentifier: An identifier of setion.
     public mutating func insertSections(_ identifiers: [SectionIdentifierType], beforeSection toIdentifier: SectionIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.insertSections(identifiers, beforeSection: toIdentifier)
+        }
         structure.insert(sectionIDs: identifiers, before: toIdentifier)
     }
 
@@ -165,6 +253,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifiers: The section identifiers to be inserted.
     ///   - toIdentifier: An identifier of setion.
     public mutating func insertSections(_ identifiers: [SectionIdentifierType], afterSection toIdentifier: SectionIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.insertSections(identifiers, afterSection: toIdentifier)
+        }
         structure.insert(sectionIDs: identifiers, after: toIdentifier)
     }
 
@@ -173,6 +264,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     /// - Parameters:
     ///   - identifiers: The section identifiers to be deleted.
     public mutating func deleteSections(_ identifiers: [SectionIdentifierType]) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.deleteSections(identifiers)
+        }
         structure.remove(sectionIDs: identifiers)
     }
 
@@ -182,6 +276,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifier: A section identifier to be moved.
     ///   - toIdentifier: An identifier of section.
     public mutating func moveSection(_ identifier: SectionIdentifierType, beforeSection toIdentifier: SectionIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.moveSection(identifier, beforeSection: toIdentifier)
+        }
         structure.move(sectionID: identifier, before: toIdentifier)
     }
 
@@ -191,6 +288,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     ///   - identifier: A section identifier to be moved.
     ///   - toIdentifier: An identifier of section.
     public mutating func moveSection(_ identifier: SectionIdentifierType, afterSection toIdentifier: SectionIdentifierType) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.moveSection(identifier, afterSection: toIdentifier)
+        }
         structure.move(sectionID: identifier, after: toIdentifier)
     }
 
@@ -199,6 +299,9 @@ public struct DiffableDataSourceSnapshot<SectionIdentifierType: Hashable, ItemId
     /// - Parameters:
     ///   - identifiers: The section identifiers to be reloaded.
     public mutating func reloadSections(_ identifiers: [SectionIdentifierType]) {
+        if #available(iOS 13.0, *), !forceFallback {
+            return nativeSnapshot.reloadSections(identifiers)
+        }
         structure.update(sectionIDs: identifiers)
     }
 }

--- a/Sources/Internal/DiffableDataSourceCore.swift
+++ b/Sources/Internal/DiffableDataSourceCore.swift
@@ -51,8 +51,8 @@ final class DiffableDataSourceCore<SectionIdentifierType: Hashable, ItemIdentifi
         }
     }
 
-    func snapshot() -> DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> {
-        var snapshot = DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>()
+    func snapshot(forceFallback: Bool) -> DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType> {
+        var snapshot = DiffableDataSourceSnapshot<SectionIdentifierType, ItemIdentifierType>(forceFallback: forceFallback)
         snapshot.structure.sections = currentSnapshot.structure.sections
         return snapshot
     }

--- a/Tests/CollectionViewDiffableDataSourceTests.swift
+++ b/Tests/CollectionViewDiffableDataSourceTests.swift
@@ -7,7 +7,7 @@ import UIKit
 final class CollectionViewDiffableDataSourceTests: XCTestCase {
     func testInit() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
@@ -16,11 +16,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testApply() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
 
         let e1 = expectation(description: "testApply() e1")
         dataSource.apply(snapshot, completion: e1.fulfill)
@@ -50,7 +50,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testSnapshot() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
@@ -65,7 +65,7 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot3.sectionIdentifiers, [])
         XCTAssertEqual(snapshot3.itemIdentifiers, [])
 
-        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshotToApply.appendSections([0, 1, 2])
         snapshotToApply.appendItems([0, 1, 2])
         dataSource.apply(snapshotToApply)
@@ -92,11 +92,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testItemIdentifier() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -107,11 +107,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testIndexPath() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -122,13 +122,13 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testNumberOfSections() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
         XCTAssertEqual(dataSource.numberOfSections(in: collectionView), 0)
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -138,11 +138,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
 
     func testNumberOfRowsInSection() {
         let collectionView = MockCollectionView()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             UICollectionViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -153,11 +153,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
     func testCellForRowAt() {
         let collectionView = MockCollectionView()
         let cell = UICollectionViewCell()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             cell
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -171,11 +171,11 @@ final class CollectionViewDiffableDataSourceTests: XCTestCase {
     func testCanMoveRowAt() {
         let collectionView = MockCollectionView()
         let cell = UICollectionViewCell()
-        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView) { _, _, _ in
+        let dataSource = CollectionViewDiffableDataSource<Int, Int>(collectionView: collectionView, forceFallback: true) { _, _, _ in
             cell
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)

--- a/Tests/DiffableDataSourceTests.swift
+++ b/Tests/DiffableDataSourceTests.swift
@@ -16,7 +16,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.appendSections(test.append)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -33,7 +33,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.appendSections(test.append)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -51,7 +51,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -67,7 +67,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -86,7 +86,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -102,7 +102,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.insertSections(test.insert, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -122,7 +122,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.deleteSections(test.delete)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -140,7 +140,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.moveSection(test.move, beforeSection: test.before)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -158,7 +158,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.moveSection(test.move, afterSection: test.after)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -194,7 +194,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
             snapshot.reloadSections(test.reload)
             XCTAssertEqual(snapshot.sectionIdentifiers, test.initial)
@@ -213,7 +213,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.appendItems(test.append)
@@ -231,7 +231,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.appendItems(test.append)
@@ -253,7 +253,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items)
@@ -276,7 +276,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items)
@@ -302,7 +302,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, beforeItem: test.before)
@@ -320,7 +320,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, beforeItem: test.before)
@@ -341,7 +341,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, afterItem: test.after)
@@ -359,7 +359,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections([0, 1])
             snapshot.appendItems(test.initial)
             snapshot.insertItems(test.insert, afterItem: test.after)
@@ -382,7 +382,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -409,7 +409,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -435,7 +435,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -463,7 +463,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -539,7 +539,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -564,7 +564,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -583,7 +583,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -602,7 +602,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.numberOfSections, test.expected)
@@ -618,7 +618,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.numberOfSections, test.expected)
@@ -636,7 +636,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -655,7 +655,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -674,7 +674,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -690,7 +690,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.sectionIdentifiers, test.expected)
@@ -708,7 +708,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -727,7 +727,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -748,7 +748,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -767,7 +767,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -789,7 +789,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -808,7 +808,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -830,7 +830,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -849,7 +849,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             for (section, items) in test.initial.enumerated() {
                 snapshot.appendSections([section])
                 snapshot.appendItems(items, toSection: section)
@@ -870,7 +870,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.indexOfSection(test.section), test.expectedIndex)
@@ -886,7 +886,7 @@ final class DiffableDataSourceSnapshotTests: XCTestCase {
         ]
 
         for test in tests {
-            var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+            var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
             snapshot.appendSections(test.initial)
 
             XCTAssertEqual(snapshot.indexOfSection(test.section), test.expectedIndex)

--- a/Tests/TableViewDiffableDataSourceTests.swift
+++ b/Tests/TableViewDiffableDataSourceTests.swift
@@ -7,7 +7,7 @@ import UIKit
 final class TableViewDiffableDataSourceTests: XCTestCase {
     func testInit() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
@@ -16,11 +16,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testApply() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
 
         let e1 = expectation(description: "testApply() e1")
         dataSource.apply(snapshot, completion: e1.fulfill)
@@ -50,7 +50,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testSnapshot() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
@@ -65,7 +65,7 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot3.sectionIdentifiers, [])
         XCTAssertEqual(snapshot3.itemIdentifiers, [])
 
-        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshotToApply = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshotToApply.appendSections([0, 1, 2])
         snapshotToApply.appendItems([0, 1, 2])
         dataSource.apply(snapshotToApply)
@@ -92,11 +92,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testItemIdentifier() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -107,11 +107,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testIndexPath() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -122,13 +122,13 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testNumberOfSections() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
         XCTAssertEqual(dataSource.numberOfSections(in: tableView), 0)
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -138,11 +138,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
 
     func testNumberOfRowsInSection() {
         let tableView = MockTableView()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             UITableViewCell()
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -153,11 +153,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
     func testCellForRowAt() {
         let tableView = MockTableView()
         let cell = UITableViewCell()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             cell
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -171,11 +171,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
     func testCanEditRowAt() {
         let tableView = MockTableView()
         let cell = UITableViewCell()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             cell
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)
@@ -189,11 +189,11 @@ final class TableViewDiffableDataSourceTests: XCTestCase {
     func testCanMoveRowAt() {
         let tableView = MockTableView()
         let cell = UITableViewCell()
-        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView) { _, _, _ in
+        let dataSource = TableViewDiffableDataSource<Int, Int>(tableView: tableView, forceFallback: true) { _, _, _ in
             cell
         }
 
-        var snapshot = DiffableDataSourceSnapshot<Int, Int>()
+        var snapshot = DiffableDataSourceSnapshot<Int, Int>(forceFallback: true)
         snapshot.appendSections([0, 1, 2])
         snapshot.appendItems([0, 1, 2], toSection: 0)
         dataSource.apply(snapshot)


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched existing pull requests for ensure not duplicated.  

## Description
This change aims to use the native diffable data source implementation whenever possible (which at this point is 90% of times). This avoids some small API discrepancies and bugs that have been fixed.

## Related Issue
https://github.com/ra1028/DiffableDataSources/issues/42

## Motivation and Context
This library has always (wisely) aimed at closely mimicking the native API because of its temporary nature. Ideally we don't want to have to use backports. But while we can't target the API we need, they are invaluable to adopt newer tech. In the case of DiffableDataSources though, we must use the backport even for the latest OS versions, which is unfortunate. The "sister" library I met along with this one was [IBPCollectionViewCompositionalLayout](https://github.com/kishikawakatsumi/IBPCollectionViewCompositionalLayout), and it very neatly and transparently uses the backport **only** when the native API is not available. This is the aim of this PR. To make the transition to fully native as seamless as possible. Just remove the shims when you can and you're good to go.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
I have wrapped native API under the existing code, so as far as I can understand there is no impact. I simply carry a native instance when the OS allows, and skip the backport one. I introduced internal init methods that enable forcing the backport so the tests could focus on testing the backports instead of what's available on the simulator running the tests. The public API is still the exact same.
